### PR TITLE
feat: .mcaln v1 motion-alignment export/import (-OutMotion / -InMotion)

### DIFF
--- a/CMcAreTomoInc.h
+++ b/CMcAreTomoInc.h
@@ -100,6 +100,8 @@ public:
 	int m_iEerSampling;
 	int m_iTiffOrder;
 	int m_iCorrInterp;
+	int m_iOutMotion;
+	int m_iInMotion;
 	//-----------------
 	char m_acGainFileTag[32];
 	char m_acDarkMrcTag[32];
@@ -120,6 +122,8 @@ public:
 	char m_acEerSamplingTag[32];
 	char m_acTiffOrderTag[32];
 	char m_acCorrInterpTag[32];
+	char m_acOutMotionTag[32];
+	char m_acInMotionTag[32];
 private:
         CMcInput(void);
         void mPrint(void);

--- a/CMcInput.cpp
+++ b/CMcInput.cpp
@@ -32,6 +32,8 @@ CMcInput::CMcInput(void)
 	strcpy(m_acIterTag, "-McIter");
 	strcpy(m_acTolTag, "-McTol");
 	strcpy(m_acMcBinTag, "-McBin");
+	strcpy(m_acOutMotionTag, "-OutMotion");
+	strcpy(m_acInMotionTag, "-InMotion");
 	strcpy(m_acThrowTag, "-Throw");
 	strcpy(m_acFmIntTag, "-FmInt");
 	strcpy(m_acGroupTag, "-Group");
@@ -65,6 +67,8 @@ CMcInput::CMcInput(void)
 	m_iEerSampling = 1;
 	m_iTiffOrder = 1;
 	m_iCorrInterp = 0;
+	m_iOutMotion = 0;
+	m_iInMotion = 0;
 }
 
 CMcInput::~CMcInput(void)
@@ -256,6 +260,14 @@ void CMcInput::Parse(int argc, char* argv[])
 	aParseArgs.FindVals(m_acCorrInterpTag, aiRange);
 	if(aiRange[1] > 1) aiRange[1] = 1;
 	aParseArgs.GetVals(aiRange, &m_iCorrInterp);
+	//-----------------
+	aParseArgs.FindVals(m_acOutMotionTag, aiRange);
+	if(aiRange[1] > 1) aiRange[1] = 1;
+	aParseArgs.GetVals(aiRange, &m_iOutMotion);
+	//-----------------
+	aParseArgs.FindVals(m_acInMotionTag, aiRange);
+	if(aiRange[1] > 1) aiRange[1] = 1;
+	aParseArgs.GetVals(aiRange, &m_iInMotion);
 	mPrint();
 }
 
@@ -316,5 +328,7 @@ void CMcInput::mPrint(void)
 	printf("%-15s  %d\n", m_acInFmMotionTag, m_iInFmMotion);
 	printf("%-15s  %d\n", m_acTiffOrderTag, m_iTiffOrder);
 	printf("%-15s  %d\n", m_acCorrInterpTag, m_iCorrInterp);
+	printf("%-15s  %d\n", m_acOutMotionTag, m_iOutMotion);
+	printf("%-15s  %d\n", m_acInMotionTag, m_iInMotion);
 	printf("\n\n");
 }

--- a/MotionCor/Align/CAlignInc.h
+++ b/MotionCor/Align/CAlignInc.h
@@ -386,30 +386,46 @@ public:
 	static void DeleteInstances(void);
 	static CSaveAlign* GetInstance(int iNthGpu);
 	~CSaveAlign(void);
-	bool Open(char* pcFileName);
-	bool Open(char* pcDirName, char* pcStackFile);
-	void SaveSetting(int* piStkSize, int* piPatches, int* piThrow);
+	//-----------------------------------------------------------
+	// Writes the .mcaln v1 motion-alignment file (frozen format,
+	// see arewarpo docs/mcaln_format.md) when -OutMotion is set.
+	// DoGlobal: full-frame path (patches 0 0, global block only).
+	// DoLocal: patch path (frame table + global + local blocks,
+	// exactly the post-MakeRelative state the correction used).
+	//-----------------------------------------------------------
 	void DoGlobal(MMD::CStackShift* pStackShift);
 	void DoLocal(MMD::CPatchShifts* pPatchShifts);
-	char* GetStartTag(char* pcTagName);
-	char* GetEndTag(char* pcTagName);
-	char m_acSetting[64];
-	char m_acStackSize[64];
-	char m_acPatches[64];
-	char m_acThrow[64];
-	char m_acGlobalShift[64];
-	char m_acLocalShift[64];
-	char m_acConverge[64];
-	char m_acStackID[64];
-	char m_acPatchID[64];
 	int m_iNthGpu;
 private:
 	CSaveAlign(void);
-	void mSaveGlobal(MMD::CStackShift* pFullShift);
-	void mSaveLocal(MMD::CPatchShifts* pPatchShifts);
-	FILE* m_pFile;
+	FILE* mOpen(void);
+	void mSaveHeader(FILE* pFile, int* piStkSize, int iPatX, int iPatY,
+	   int iNumFrames);
+	void mSaveGlobal(FILE* pFile, MMD::CStackShift* pFullShift);
 	static CSaveAlign* m_pInstances;
 	static int m_iNumGpus;
+};
+
+//-----------------------------------------------------------------
+// Reads a .mcaln v1 file (-InMotion) and rebuilds CStackShift /
+// CPatchShifts so the correction stages can run without any
+// measurement. MakeRelative is NOT applied - file shifts are final.
+//-----------------------------------------------------------------
+class CLoadAlign
+{
+public:
+	CLoadAlign(void);
+	~CLoadAlign(void);
+	bool DoIt(int iNthGpu);          // parse <OutDir>/<movie>.mcaln
+	MMD::CStackShift* m_pFullShift;   // caller owns after Take*
+	MMD::CPatchShifts* m_pPatchShifts; // 0L when patches 0 0
+	MMD::CStackShift* TakeFullShift(void);
+	MMD::CPatchShifts* TakePatchShifts(void);
+private:
+	bool mParse(const char* pcPath, int* piStkSize);
+	void mSetPatchShift(int iFrame, int iPatch, float* pfShift,
+	   bool bValid);
+	void mClean(void);
 };
 
 class GNormByStd2D
@@ -471,6 +487,7 @@ public:
 	~CAlignMain(void);
 	void DoIt(int iNthGpu);
 private:
+	bool mCorrectFromFile(void);
 	char* mCreateLogFile(void);
 	int m_iNthGpu;
 };

--- a/MotionCor/Align/CAlignMain.cpp
+++ b/MotionCor/Align/CAlignMain.cpp
@@ -1,4 +1,5 @@
 #include "CAlignInc.h"
+#include "../Correct/CCorrectInc.h"
 #include <memory.h>
 #include <stdio.h>
 #include <cuda.h>
@@ -6,6 +7,7 @@
 #include <cufft.h>
 
 using namespace McAreTomo::MotionCor::Align;
+namespace MMC = McAreTomo::MotionCor::Correct;
 
 CAlignMain::CAlignMain(void)
 {
@@ -18,6 +20,17 @@ CAlignMain::~CAlignMain(void)
 void CAlignMain::DoIt(int iNthGpu)
 {
 	m_iNthGpu = iNthGpu;
+	//-----------------------------------------------------------
+	// -InMotion 1: replay a .mcaln motion alignment through the
+	// correction stages only, skipping all measurement. Falls
+	// back to measurement when the file cannot be loaded.
+	//-----------------------------------------------------------
+	CMcInput* pMcInputMotion = CMcInput::GetInstance();
+	if(pMcInputMotion->m_iInMotion != 0)
+	{	if(mCorrectFromFile()) return;
+		fprintf(stderr, "Warning: -InMotion failed, falling back "
+		   "to motion measurement.\n\n");
+	}
 	//-----------------
 	MD::CMcPackage* pMcPackage = MD::CMcPackage::GetInstance(m_iNthGpu);
 	float fTilt = pMcPackage->m_fTilt;
@@ -48,5 +61,46 @@ void CAlignMain::DoIt(int iNthGpu)
 
 char* CAlignMain::mCreateLogFile(void)
 {	return 0L;	
+}
+
+bool CAlignMain::mCorrectFromFile(void)
+{
+	CLoadAlign aLoadAlign;
+	if(!aLoadAlign.DoIt(m_iNthGpu)) return false;
+	//-----------------------------------------------------------
+	// Buffer prep + forward FFT of the frame stack, exactly as
+	// CFullAlign::Align does before any measurement.
+	//-----------------------------------------------------------
+	CAlignBase aAlignBase;
+	aAlignBase.Clean();
+	aAlignBase.DoIt(m_iNthGpu);
+	//-----------------
+	bool bForward = true, bNorm = true;
+	CTransformStack aTransformStack;
+	aTransformStack.Setup(MD::EBuffer::frm, bForward, bNorm, m_iNthGpu);
+	aTransformStack.DoIt();
+	//-----------------
+	MMD::CPatchShifts* pPatchShifts = aLoadAlign.TakePatchShifts();
+	if(pPatchShifts == 0L)
+	{	MMD::CStackShift* pFullShift = aLoadAlign.TakeFullShift();
+		MMC::CCorrectFullShift aCorrFullShift;
+		aCorrFullShift.Setup(pFullShift, m_iNthGpu);
+		aCorrFullShift.DoIt();
+		delete pFullShift;
+	}
+	else
+	{	// Global correction in place (Fourier phase shift), then
+		// the residual local field - the same sequence as the
+		// patch path. NO MakeRelative: file shifts are final.
+		MMC::CGenRealStack aGenRealStack;
+		bool bGenReal = true;
+		aGenRealStack.Setup(MD::EBuffer::frm, !bGenReal, m_iNthGpu);
+		aGenRealStack.DoIt(pPatchShifts->m_pFullShift);
+		//-----------------
+		MMC::GCorrectPatchShift aCorrPatchShift;
+		aCorrPatchShift.DoIt(pPatchShifts, m_iNthGpu);
+		delete pPatchShifts;
+	}
+	return true;
 }
 

--- a/MotionCor/Align/CLoadAlign.cpp
+++ b/MotionCor/Align/CLoadAlign.cpp
@@ -1,0 +1,202 @@
+//-------------------------------------------------------------------
+// CLoadAlign: reads a .mcaln v1 motion-alignment file (-InMotion 1)
+// from <OutDir>/<movie basename>.mcaln and rebuilds CStackShift /
+// CPatchShifts so the correction stages can run without measurement.
+// MakeRelative is NOT applied - file shifts are final (frozen format,
+// see the arewarpo docs/mcaln_format.md).
+//-------------------------------------------------------------------
+#include "CAlignInc.h"
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+using namespace McAreTomo::MotionCor::Align;
+
+CLoadAlign::CLoadAlign(void)
+{
+	m_pFullShift = 0L;
+	m_pPatchShifts = 0L;
+}
+
+CLoadAlign::~CLoadAlign(void)
+{
+	mClean();
+}
+
+void CLoadAlign::mClean(void)
+{
+	if(m_pFullShift != 0L) delete m_pFullShift;
+	if(m_pPatchShifts != 0L) delete m_pPatchShifts;
+	m_pFullShift = 0L;
+	m_pPatchShifts = 0L;
+}
+
+MMD::CStackShift* CLoadAlign::TakeFullShift(void)
+{
+	MMD::CStackShift* p = m_pFullShift;
+	m_pFullShift = 0L;
+	return p;
+}
+
+MMD::CPatchShifts* CLoadAlign::TakePatchShifts(void)
+{
+	MMD::CPatchShifts* p = m_pPatchShifts;
+	m_pPatchShifts = 0L;
+	return p;
+}
+
+bool CLoadAlign::DoIt(int iNthGpu)
+{
+	mClean();
+	//-----------------
+	CInput* pInput = CInput::GetInstance();
+	MD::CMcPackage* pMcPackage = MD::CMcPackage::GetInstance(iNthGpu);
+	MD::CBufferPool* pBufferPool = MD::CBufferPool::GetInstance(iNthGpu);
+	//-----------------
+	char acPath[512] = {'\0'};
+	strcpy(acPath, pInput->m_acOutDir);
+	int iSize = strlen(acPath);
+	if(iSize > 0 && acPath[iSize-1] != '/') strcat(acPath, "/");
+	char* pcSlash = strrchr(pMcPackage->m_acMoviePath, '/');
+	char* pcName = (pcSlash == 0L) ? pMcPackage->m_acMoviePath
+	   : pcSlash + 1;
+	strcat(acPath, pcName);
+	char* pcDot = strrchr(acPath, '.');
+	if(pcDot == 0L) strcat(acPath, ".mcaln");
+	else strcpy(pcDot, ".mcaln");
+	//-----------------
+	bool bLoaded = mParse(acPath, pBufferPool->m_aiStkSize);
+	if(!bLoaded)
+	{	fprintf(stderr, "Error: -InMotion could not load %s\n\n",
+		   acPath);
+		mClean();
+	}
+	else printf("Motion alignment loaded: %s\n", acPath);
+	return bLoaded;
+}
+
+bool CLoadAlign::mParse(const char* pcPath, int* piStkSize)
+{
+	FILE* pFile = fopen(pcPath, "rt");
+	if(pFile == 0L) return false;
+	//-----------------
+	char acLine[512] = {'\0'};
+	if(fgets(acLine, sizeof(acLine), pFile) == 0L ||
+	   strncmp(acLine, "# AreTomo3 MotionAlign 1.0", 26) != 0)
+	{	fprintf(stderr, "Error: %s is not a "
+		   ".mcaln v1 file.\n", pcPath);
+		fclose(pFile);
+		return false;
+	}
+	//-----------------
+	int iSizeX = 0, iSizeY = 0, iAligned = 0;
+	int iPatX = 0, iPatY = 0;
+	int iSection = 0; // 1 setting, 2 frameTable, 3 global, 4 local
+	int iPatchSlot = -1;
+	//-----------------
+	while(fgets(acLine, sizeof(acLine), pFile) != 0L)
+	{	char* pcTrim = acLine;
+		while(*pcTrim == ' ' || *pcTrim == '\t') pcTrim++;
+		if(*pcTrim == '\n' || *pcTrim == '\0') continue;
+		//----------------
+		if(strncmp(pcTrim, "setting", 7) == 0)
+		{	iSection = 1; continue;
+		}
+		else if(strncmp(pcTrim, "frameTable", 10) == 0)
+		{	iSection = 2; continue;
+		}
+		else if(strncmp(pcTrim, "globalShift", 11) == 0)
+		{	iSection = 3;
+			if(iAligned <= 0 || iSizeX <= 0) break;
+			m_pFullShift = new MMD::CStackShift;
+			m_pFullShift->Setup(iAligned);
+			if(iPatX * iPatY > 0)
+			{	int aiFull[] = {iSizeX, iSizeY, iAligned};
+				m_pPatchShifts = new MMD::CPatchShifts;
+				m_pPatchShifts->Setup(iPatX * iPatY, aiFull);
+			}
+			continue;
+		}
+		else if(strncmp(pcTrim, "localShift", 10) == 0)
+		{	iSection = 4; iPatchSlot = -1; continue;
+		}
+		//----------------
+		if(iSection == 1)
+		{	if(strncmp(pcTrim, "aligned_frame_count:", 20) == 0)
+			{	iAligned = atoi(pcTrim + 20);
+			}
+			else if(strncmp(pcTrim,
+			   "alignment_image_size_px:", 24) == 0)
+			{	sscanf(pcTrim + 24, "%d %d",
+				   &iSizeX, &iSizeY);
+			}
+			else if(strncmp(pcTrim, "patches:", 8) == 0)
+			{	sscanf(pcTrim + 8, "%d %d", &iPatX, &iPatY);
+			}
+			else if(strncmp(pcTrim, "frame_index_base:", 17) == 0)
+			{	if(atoi(pcTrim + 17) != 0) break;
+			}
+		}
+		else if(iSection == 3)
+		{	int iFrame = -1;
+			float afShift[2] = {0.0f};
+			if(sscanf(pcTrim, "%d %f %f", &iFrame,
+			   afShift, afShift + 1) != 3) break;
+			if(iFrame < 0 || iFrame >= iAligned) break;
+			m_pFullShift->SetShift(iFrame, afShift);
+		}
+		else if(iSection == 4 && m_pPatchShifts != 0L)
+		{	if(strncmp(pcTrim, "patchID:", 8) == 0)
+			{	iPatchSlot = atoi(pcTrim + 8);
+				continue;
+			}
+			int iFrame = -1, iValid = 1;
+			float afCent[2] = {0.0f}, afShift[2] = {0.0f};
+			if(sscanf(pcTrim, "%d %f %f %f %f %d", &iFrame,
+			   afCent, afCent + 1, afShift, afShift + 1,
+			   &iValid) != 6) break;
+			if(iPatchSlot < 0 ||
+			   iPatchSlot >= iPatX * iPatY) break;
+			if(iFrame < 0 || iFrame >= iAligned) break;
+			//----------------
+			if(iFrame == 0)
+			{	// per-patch center: buffer via a stack
+				// shift so SetRawShift stores it.
+				MMD::CStackShift aShift;
+				aShift.Setup(iAligned);
+				aShift.SetCenter(afCent[0], afCent[1]);
+				m_pPatchShifts->SetRawShift(&aShift,
+				   iPatchSlot);
+			}
+			float afLocal[] = {afShift[0], afShift[1]};
+			mSetPatchShift(iFrame, iPatchSlot, afLocal,
+			   iValid != 0);
+		}
+	}
+	fclose(pFile);
+	//-----------------
+	if(m_pFullShift == 0L) return false;
+	if(iSizeX != piStkSize[0] || iSizeY != piStkSize[1] ||
+	   iAligned != piStkSize[2])
+	{	fprintf(stderr, "Error: .mcaln geometry (%d x %d x %d) "
+		   "does not match the loaded stack (%d x %d x %d).\n",
+		   iSizeX, iSizeY, iAligned, piStkSize[0],
+		   piStkSize[1], piStkSize[2]);
+		return false;
+	}
+	if(m_pPatchShifts != 0L)
+	{	m_pPatchShifts->SetFullShift(m_pFullShift->GetCopy());
+	}
+	return true;
+}
+
+void CLoadAlign::mSetPatchShift
+(	int iFrame,
+	int iPatch,
+	float* pfShift,
+	bool bValid
+)
+{	m_pPatchShifts->SetLocalShift(iFrame, iPatch, pfShift);
+	m_pPatchShifts->SetBadFlag(iFrame, iPatch, !bValid);
+}

--- a/MotionCor/Align/CSaveAlign.cpp
+++ b/MotionCor/Align/CSaveAlign.cpp
@@ -128,10 +128,6 @@ void CSaveAlign::mSaveHeader
 	fprintf(pFile, "   patches: %d %d\n", iPatX, iPatY);
 	fprintf(pFile, "   fmRef: %d\n", iFmRef);
 	fprintf(pFile, "   frame_index_base: 0\n");
-	fprintf(pFile, "   pixel_center_offset: 0.0\n");
-	fprintf(pFile, "   coordinate_space: "
-	   "alignment-image-px, corner-origin\n");
-	fprintf(pFile, "   map_direction: corrected->raw (out(x)=in(x-s))\n");
 	//-----------------
 	fprintf(pFile, "frameTable\n");
 	for(int i=0; i<pFmIntParam->GetProvNumIntFrames(); i++)

--- a/MotionCor/Align/CSaveAlign.cpp
+++ b/MotionCor/Align/CSaveAlign.cpp
@@ -1,3 +1,13 @@
+//-------------------------------------------------------------------
+// CSaveAlign: writes the .mcaln v1 motion-alignment file when
+// -OutMotion 1 is given. Format frozen 2026-08-28; see the arewarpo
+// docs/mcaln_format.md for the pinned semantics:
+//   raw(x, f) = x - S_local(x, f) - glob_f
+// with globalShift = FmRef-relative full shifts and localShift = the
+// post-MakeRelative residual patch shifts, exactly the state the
+// correction kernels consumed. Coordinates are alignment-image pixel
+// indices, corner origin.
+//-------------------------------------------------------------------
 #include "CAlignInc.h"
 #include <memory.h>
 #include <math.h>
@@ -35,131 +45,159 @@ CSaveAlign* CSaveAlign::GetInstance(int iNthGpu)
 
 CSaveAlign::CSaveAlign(void)
 {
-	strcpy(m_acSetting, "setting");
-	strcpy(m_acStackSize, "stackSize");
-	strcpy(m_acPatches, "patches");
-	strcpy(m_acThrow, "throw");
-	strcpy(m_acGlobalShift, "globalShift");
-	strcpy(m_acLocalShift, "localShift");
-	strcpy(m_acConverge, "Converge");
-	strcpy(m_acStackID, "stackID");
-	strcpy(m_acPatchID, "patchID");
-	//-----------------
-	m_pFile = 0L;
 }
 
 CSaveAlign::~CSaveAlign(void)
 {
-	if(m_pFile != 0L) fclose(m_pFile);
 }
 
-bool CSaveAlign::Open(char* pcFileName)
+//-------------------------------------------------------------------
+// <OutDir>/<movie basename>.mcaln
+//-------------------------------------------------------------------
+FILE* CSaveAlign::mOpen(void)
 {
-     if(m_pFile != 0L) fclose(m_pFile);
-     m_pFile = 0L;
-     //-----------
-     if(pcFileName == 0L || strlen(pcFileName) == 0) return false;
-     //-----------------------------------------------------------
-     m_pFile = fopen(pcFileName, "wt");
-     if(m_pFile != 0L) return true;
-     //----------------------------
-     printf
-     ( "Info: %s\n",
-       "      cannot be opened. Alignment wiil not be saved.\n\n"
-     );
-     return false;
+	CInput* pInput = CInput::GetInstance();
+	MD::CMcPackage* pMcPackage = MD::CMcPackage::GetInstance(m_iNthGpu);
+	//-----------------
+	char acPath[512] = {'\0'};
+	strcpy(acPath, pInput->m_acOutDir);
+	int iSize = strlen(acPath);
+	if(iSize > 0 && acPath[iSize-1] != '/') strcat(acPath, "/");
+	//-----------------
+	char* pcSlash = strrchr(pMcPackage->m_acMoviePath, '/');
+	char* pcName = (pcSlash == 0L) ? pMcPackage->m_acMoviePath
+	   : pcSlash + 1;
+	strcat(acPath, pcName);
+	char* pcDot = strrchr(acPath, '.');
+	if(pcDot == 0L) strcat(acPath, ".mcaln");
+	else strcpy(pcDot, ".mcaln");
+	//-----------------
+	FILE* pFile = fopen(acPath, "wt");
+	if(pFile == 0L)
+	{	fprintf(stderr, "Warning: cannot open %s for writing, "
+		   "motion alignment not saved.\n\n", acPath);
+	}
+	else printf("Motion alignment saved: %s\n", acPath);
+	return pFile;
 }
 
-bool CSaveAlign::Open(char* pcDirName, char* pcStackFile)
-{
-     if(m_pFile != 0L) fclose(m_pFile);
-     m_pFile = 0L;
-     //-----------
-     int iSize = strlen(pcDirName);
-     if(pcDirName == 0L || iSize == 0) return false;
-     //---------------------------------------------------------
-     char acFileName[256] = {'\0'};
-     strcpy(acFileName, pcDirName);
-     if(pcDirName[iSize - 1] != '/') strcat(acFileName, "/");
-     //------------------------------------------------------
-     char* pcSlash = strrchr(pcStackFile, '/');
-     char* pcFileName = (pcSlash == 0L) ? pcStackFile : pcSlash+1;
-     strcat(acFileName, pcFileName);
-     //-----------------------------
-     char* pcDot = strrchr(acFileName, '.');
-     if(pcDot == 0L) strcat(acFileName, ".aln");
-     else strcpy(pcDot, ".aln");
-     //-------------------------
-     return this->Open(acFileName);
-}
-
-void CSaveAlign::SaveSetting
-(	int* piStkSize,
-	int* piPatches,
-	int* piThrow
+void CSaveAlign::mSaveHeader
+(	FILE* pFile,
+	int* piStkSize,
+	int iPatX,
+	int iPatY,
+	int iNumFrames
 )
-{	if(m_pFile == 0L) return;
-	//-----------------------
-	fseek(m_pFile, 0L, SEEK_SET);
-	fprintf(m_pFile, "%s\n", m_acSetting);
-	fprintf(m_pFile, "   %s: %d %d %d %d\n", m_acStackSize,
-	   piStkSize[0], piStkSize[1], piStkSize[2], 1);
-	fprintf(m_pFile, "   %s: %d %d %d\n", m_acPatches,
-	   piPatches[0], piPatches[1], piPatches[2]);
-	fprintf(m_pFile, "   %s: %d %d\n", m_acThrow, 
-	   piThrow[0], piThrow[1]);      
+{	CMcInput* pMcInput = CMcInput::GetInstance();
+	MD::CMcPackage* pMcPackage = MD::CMcPackage::GetInstance(m_iNthGpu);
+	MMD::CFmIntParam* pFmIntParam =
+	   MMD::CFmIntParam::GetInstance(m_iNthGpu);
+	CAlignParam* pAlignParam = CAlignParam::GetInstance();
+	//-----------------
+	int iFmRef = pAlignParam->GetFrameRef(iNumFrames);
+	//-----------------------------------------------------------
+	// Pixel size of the ALIGNMENT grid (the frame buffer the
+	// shifts live on): the final sum pixel scaled back by the
+	// binning applied after alignment. E.g. EER sampling 2 +
+	// McBin 2: alignment at 8192 px / 0.77 A, sums at 4096 / 1.54.
+	//-----------------------------------------------------------
+	int aiBinned[2] = {0};
+	pMcInput->GetBinnedSize(piStkSize, aiBinned);
+	float fPixSize = pMcInput->GetFinalPixelSize();
+	if(piStkSize[0] > 0)
+	{	fPixSize = fPixSize * aiBinned[0] / (float)piStkSize[0];
+	}
+	int* piMovieSize = pMcPackage->GetMovieSize();
+	float fScaleX = (piMovieSize[0] > 0) ?
+	   piStkSize[0] / (float)piMovieSize[0] : 1.0f;
+	float fScaleY = (piMovieSize[1] > 0) ?
+	   piStkSize[1] / (float)piMovieSize[1] : 1.0f;
+	//-----------------
+	fprintf(pFile, "# AreTomo3 MotionAlign 1.0\n");
+	fprintf(pFile, "setting\n");
+	fprintf(pFile, "   raw_frame_count: %d\n",
+	   pFmIntParam->GetNumRawFrames());
+	fprintf(pFile, "   integrated_frame_count: %d\n",
+	   pFmIntParam->GetProvNumIntFrames());
+	fprintf(pFile, "   aligned_frame_count: %d\n", iNumFrames);
+	fprintf(pFile, "   alignment_image_size_px: %d %d\n",
+	   piStkSize[0], piStkSize[1]);
+	fprintf(pFile, "   alignment_pixel_size_A: %.6g\n", fPixSize);
+	fprintf(pFile, "   input_to_alignment_scale_xy: %.6g %.6g\n",
+	   fScaleX, fScaleY);
+	fprintf(pFile, "   patches: %d %d\n", iPatX, iPatY);
+	fprintf(pFile, "   fmRef: %d\n", iFmRef);
+	fprintf(pFile, "   frame_index_base: 0\n");
+	fprintf(pFile, "   pixel_center_offset: 0.0\n");
+	fprintf(pFile, "   coordinate_space: "
+	   "alignment-image-px, corner-origin\n");
+	fprintf(pFile, "   map_direction: corrected->raw (out(x)=in(x-s))\n");
+	//-----------------
+	fprintf(pFile, "frameTable\n");
+	for(int i=0; i<pFmIntParam->GetProvNumIntFrames(); i++)
+	{	fprintf(pFile, "   %4d %6d %5d %d %4d\n", i,
+		   pFmIntParam->GetProvStart(i),
+		   pFmIntParam->GetProvSize(i),
+		   pFmIntParam->GetProvIncluded(i) ? 1 : 0,
+		   pFmIntParam->GetProvAligned(i));
+	}
+}
+
+void CSaveAlign::mSaveGlobal(FILE* pFile, MMD::CStackShift* pFullShift)
+{
+	fprintf(pFile, "globalShift\n");
+	float afShift[2] = {0.0f};
+	for(int i=0; i<pFullShift->m_iNumFrames; i++)
+	{	pFullShift->GetShift(i, afShift);
+		fprintf(pFile, "   %4d %10.4f %10.4f\n",
+		   i, afShift[0], afShift[1]);
+	}
 }
 
 void CSaveAlign::DoGlobal(MMD::CStackShift* pFullShift)
 {
-	if(m_pFile == 0L) return;
-	mSaveGlobal(pFullShift);
+	CMcInput* pMcInput = CMcInput::GetInstance();
+	if(pMcInput->m_iOutMotion == 0) return;
+	if(pFullShift == 0L) return;
+	//-----------------
+	FILE* pFile = mOpen();
+	if(pFile == 0L) return;
+	//-----------------
+	MD::CBufferPool* pBufferPool =
+	   MD::CBufferPool::GetInstance(m_iNthGpu);
+	mSaveHeader(pFile, pBufferPool->m_aiStkSize, 0, 0,
+	   pFullShift->m_iNumFrames);
+	mSaveGlobal(pFile, pFullShift);
+	fclose(pFile);
 }
 
 void CSaveAlign::DoLocal(MMD::CPatchShifts* pPatchShifts)
 {
-	if(m_pFile == 0L) return;
-	mSaveGlobal(pPatchShifts->m_pFullShift);
-	mSaveLocal(pPatchShifts);
-}
-
-void CSaveAlign::mSaveGlobal(MMD::CStackShift* pFullShift)
-{
-	fprintf(m_pFile, "#    Global Shift\n");
-	fprintf(m_pFile, "#---------------------\n");
-	fprintf(m_pFile, "%s\n", m_acGlobalShift);
-	fprintf(m_pFile, "   %s %d\n", m_acStackID, 0);
-	//---------------------------------------------
-	float afShift[2] = {0.0f};
-	for(int i=0; i<pFullShift->m_iNumFrames; i++)
-	{	pFullShift->GetShift(i, afShift);
-		fprintf(m_pFile, "%6d  %+8.3f  %+8.3f\n", 
-		   i, afShift[0], afShift[1]);
-     	}
-}
-
-void CSaveAlign::mSaveLocal(MMD::CPatchShifts* pPatchShifts)
-{
-	fprintf(m_pFile, "#    Local Shift\n");
-	fprintf(m_pFile, "#---------------------\n");
-	fprintf(m_pFile, "%s\n", m_acLocalShift);
-	//---------------------------------------
-	float afPatCent[2] = {0.0f}, afShift[2] = {0.0f};
-	int iLastPatch = pPatchShifts->m_iNumPatches - 1;
-	//-----------------------------------------------
-	for(int i=0; i<pPatchShifts->m_iNumPatches; i++)
-	{	fprintf(m_pFile, "   %s: %d\n", m_acPatchID, i);
-		fprintf(m_pFile, "   %s: %d\n", m_acConverge, 1);
-		//-----------------------------------------------
-		pPatchShifts->GetPatchCenter(i, afPatCent);
-		for(int j=0; j<pPatchShifts->m_aiFullSize[2]; j++)
-		{	pPatchShifts->GetLocalShift(j, i, afShift);
-			fprintf(m_pFile, "%6d  %8.2f  %8.2f  %+8.3f  %+8.3f\n",
-			   j, afPatCent[0], afPatCent[1], 
-			   afShift[0], afShift[1]);
+	CMcInput* pMcInput = CMcInput::GetInstance();
+	if(pMcInput->m_iOutMotion == 0) return;
+	if(pPatchShifts == 0L) return;
+	//-----------------
+	FILE* pFile = mOpen();
+	if(pFile == 0L) return;
+	//-----------------
+	int iNumFrames = pPatchShifts->m_aiFullSize[2];
+	mSaveHeader(pFile, pPatchShifts->m_aiFullSize,
+	   pMcInput->m_aiNumPatches[0], pMcInput->m_aiNumPatches[1],
+	   iNumFrames);
+	mSaveGlobal(pFile, pPatchShifts->m_pFullShift);
+	//-----------------
+	float afCenter[2] = {0.0f}, afShift[2] = {0.0f};
+	for(int p=0; p<pPatchShifts->m_iNumPatches; p++)
+	{	fprintf(pFile, "localShift\n");
+		fprintf(pFile, "   patchID: %d\n", p);
+		pPatchShifts->GetPatchCenter(p, afCenter);
+		for(int f=0; f<iNumFrames; f++)
+		{	pPatchShifts->GetLocalShift(f, p, afShift);
+			bool bBad = pPatchShifts->GetBadFlag(f, p);
+			fprintf(pFile, "   %4d %9.2f %9.2f %9.3f %9.3f %d\n",
+			   f, afCenter[0], afCenter[1],
+			   afShift[0], afShift[1], bBad ? 0 : 1);
 		}
-		if(i < iLastPatch) fprintf(m_pFile, "\n");
 	}
+	fclose(pFile);
 }
-
-

--- a/MotionCor/DataUtil/CDataUtilInc.h
+++ b/MotionCor/DataUtil/CDataUtilInc.h
@@ -33,6 +33,17 @@ public:
         int GetIntFmStart(int iIntFrame);
         int GetIntFmSize(int iIntFrame);
         int GetNumIntFrames(void);
+        //-----------------------------------------------------------
+        // Immutable frame provenance retained BEFORE mRemoveFrames
+        // compacts the integration arrays (needed by CSaveAlign to
+        // write the .mcaln frame table; see arewarpo docs).
+        //-----------------------------------------------------------
+        int GetNumRawFrames(void);
+        int GetProvNumIntFrames(void);        // pre-throw count
+        int GetProvStart(int iIntFrame);      // source_start
+        int GetProvSize(int iIntFrame);       // source_count
+        bool GetProvIncluded(int iIntFrame);
+        int GetProvAligned(int iIntFrame);    // aligned index or -1
         float GetIntFmDose(int iIntFrame);
         float GetAccDose(int iIntFrame);
         float GetTotalDose(void);
@@ -55,6 +66,11 @@ private:
         int* m_piIntFmSizes;
         int m_iNumRawFms;   // All frames in the input movie file
         int m_iMrcMode;
+        int* m_piProvStarts;   // pre-throw provenance (see getters)
+        int* m_piProvSizes;
+        int m_iProvIntFms;
+        int m_iProvKeepFirst;  // first kept pre-throw index
+        int m_iProvKeepCount;
         //-----------------
         static CFmIntParam* m_pInstances;
         static int m_iNumGpus;
@@ -176,6 +192,9 @@ public:
 	void CopyFlagsToGpu(bool* gbBadShifts);
 	void MakeRelative(void);
 	void DetectBads(void);
+	void SetBadFlag(int iFrame, int iPatch, bool bBad);
+	bool GetBadFlag(int iFrame, int iPatch);
+	void SetLocalShift(int iFrame, int iPatch, float* pfShift);
 	//-----------------
 	CStackShift* m_pFullShift; // shifts of full frames
 	int m_iNumPatches;

--- a/MotionCor/DataUtil/CFmIntParam.cpp
+++ b/MotionCor/DataUtil/CFmIntParam.cpp
@@ -45,6 +45,11 @@ CFmIntParam::CFmIntParam(void)
 	m_fTotalDose = 0.0f;
 	m_iNumIntFms = 0;
 	m_iMrcMode = -1;
+	m_piProvStarts = 0L;
+	m_piProvSizes = 0L;
+	m_iProvIntFms = 0;
+	m_iProvKeepFirst = 0;
+	m_iProvKeepCount = 0;
 }
 
 
@@ -62,8 +67,62 @@ void CFmIntParam::Setup(int iNumRawFms, int iMrcMode, float fMdocDose)
 	m_iMrcMode = iMrcMode;
 	//-----------------
 	m_fTotalDose = fMdocDose;
-	mCalcIntFms(); 
+	mCalcIntFms();
+	//-----------------------------------------------------------
+	// Snapshot the pre-throw integration layout before
+	// mRemoveFrames compacts the arrays in place (frame
+	// provenance for the .mcaln frame table).
+	//-----------------------------------------------------------
+	m_iProvIntFms = m_iNumIntFms;
+	m_piProvStarts = new int[m_iProvIntFms * 2];
+	m_piProvSizes = m_piProvStarts + m_iProvIntFms;
+	for(int i=0; i<m_iProvIntFms; i++)
+	{	m_piProvStarts[i] = m_piIntFmStarts[i];
+		m_piProvSizes[i] = m_piIntFmSizes[i];
+	}
+	//-----------------
 	mRemoveFrames();
+	//-----------------
+	int iThrows = m_iProvIntFms - m_iNumIntFms;
+	if(iThrows > 0)
+	{	CMcInput* pIn = CMcInput::GetInstance();
+		m_iProvKeepFirst = pIn->m_aiThrow[0];
+	}
+	else m_iProvKeepFirst = 0;
+	m_iProvKeepCount = m_iNumIntFms;
+}
+
+int CFmIntParam::GetNumRawFrames(void)
+{
+	return m_iNumRawFms;
+}
+
+int CFmIntParam::GetProvNumIntFrames(void)
+{
+	return m_iProvIntFms;
+}
+
+int CFmIntParam::GetProvStart(int iIntFrame)
+{
+	return m_piProvStarts[iIntFrame];
+}
+
+int CFmIntParam::GetProvSize(int iIntFrame)
+{
+	return m_piProvSizes[iIntFrame];
+}
+
+bool CFmIntParam::GetProvIncluded(int iIntFrame)
+{
+	if(iIntFrame < m_iProvKeepFirst) return false;
+	if(iIntFrame >= m_iProvKeepFirst + m_iProvKeepCount) return false;
+	return true;
+}
+
+int CFmIntParam::GetProvAligned(int iIntFrame)
+{
+	if(!GetProvIncluded(iIntFrame)) return -1;
+	return iIntFrame - m_iProvKeepFirst;
 }
 
 int CFmIntParam::GetIntFmStart(int iIntFrame)
@@ -160,6 +219,12 @@ void CFmIntParam::mClean(void)
 	{	delete[] m_piIntFmStarts;
 		m_piIntFmStarts = 0L;
 		m_piIntFmSizes = 0L;
+	}
+	if(m_piProvStarts != 0L)
+	{	delete[] m_piProvStarts;
+		m_piProvStarts = 0L;
+		m_piProvSizes = 0L;
+		m_iProvIntFms = 0;
 	}
 	if(m_pfIntFmDoses != 0L) 
 	{	delete[] m_pfIntFmDoses;

--- a/MotionCor/DataUtil/CPatchShifts.cpp
+++ b/MotionCor/DataUtil/CPatchShifts.cpp
@@ -94,6 +94,23 @@ void CPatchShifts::CopyShiftsToGpu(float* gfPatShifts)
 	cudaMemcpy(gfPatShifts, m_pfPatShifts, iBytes, cudaMemcpyDefault);
 }
 
+void CPatchShifts::SetLocalShift(int iFrame, int iPatch, float* pfShift)
+{
+	int iOffset = (iFrame * m_iNumPatches + iPatch) * 2;
+	m_pfPatShifts[iOffset] = pfShift[0];
+	m_pfPatShifts[iOffset + 1] = pfShift[1];
+}
+
+void CPatchShifts::SetBadFlag(int iFrame, int iPatch, bool bBad)
+{
+	m_pbBadShifts[iFrame * m_iNumPatches + iPatch] = bBad;
+}
+
+bool CPatchShifts::GetBadFlag(int iFrame, int iPatch)
+{
+	return m_pbBadShifts[iFrame * m_iNumPatches + iPatch];
+}
+
 void CPatchShifts::CopyFlagsToGpu(bool* gbBadShifts)
 {
 	int iBytes = m_iNumPatches * m_aiFullSize[2] * sizeof(bool);

--- a/makefile
+++ b/makefile
@@ -142,6 +142,7 @@ SRCS = ./MaUtil/CParseArgs.cpp \
 	./MotionCor/Align/CPatchAlign.cpp \
 	./MotionCor/Align/CPatchCenters.cpp \
 	./MotionCor/Align/CSaveAlign.cpp \
+	./MotionCor/Align/CLoadAlign.cpp \
 	./MotionCor/Align/CSimpleSum.cpp \
 	./MotionCor/Align/CTransformStack.cpp \
 	./MotionCor/Correct/CCorrectFullShift.cpp \

--- a/makefile11
+++ b/makefile11
@@ -145,6 +145,7 @@ SRCS = ./MaUtil/CParseArgs.cpp \
 	./MotionCor/Align/CPatchAlign.cpp \
 	./MotionCor/Align/CPatchCenters.cpp \
 	./MotionCor/Align/CSaveAlign.cpp \
+	./MotionCor/Align/CLoadAlign.cpp \
 	./MotionCor/Align/CSimpleSum.cpp \
 	./MotionCor/Align/CTransformStack.cpp \
 	./MotionCor/Correct/CCorrectFullShift.cpp \

--- a/makefile12
+++ b/makefile12
@@ -145,6 +145,7 @@ SRCS = ./MaUtil/CParseArgs.cpp \
 	./MotionCor/Align/CPatchAlign.cpp \
 	./MotionCor/Align/CPatchCenters.cpp \
 	./MotionCor/Align/CSaveAlign.cpp \
+	./MotionCor/Align/CLoadAlign.cpp \
 	./MotionCor/Align/CSimpleSum.cpp \
 	./MotionCor/Align/CTransformStack.cpp \
 	./MotionCor/Correct/CCorrectFullShift.cpp \

--- a/makefile13
+++ b/makefile13
@@ -145,6 +145,7 @@ SRCS = ./MaUtil/CParseArgs.cpp \
 	./MotionCor/Align/CPatchAlign.cpp \
 	./MotionCor/Align/CPatchCenters.cpp \
 	./MotionCor/Align/CSaveAlign.cpp \
+	./MotionCor/Align/CLoadAlign.cpp \
 	./MotionCor/Align/CSimpleSum.cpp \
 	./MotionCor/Align/CTransformStack.cpp \
 	./MotionCor/Correct/CCorrectFullShift.cpp \


### PR DESCRIPTION
## Summary

Adds a versioned text format (.mcaln v1) for AreTomo3's 2D beam-induced-motion alignments, so a motion correction can be exported and replayed exactly. Two new flags, both default 0 — no change in behaviour unless enabled.

**`-OutMotion 1 — export`**

- `CSaveAlign` (previously dead code) rewritten as the writer, wired through the existing `DoGlobal`/`DoLocal` call sites. Writes `<OutDir>/<movie basename>.mcaln`.
- Contents: a frameTable (per integrated frame: source start/count, included flag, aligned index — covers `-Throw`, EER grouping and preprocessing); `globalShift` as FmRef-relative full shifts (`glob[fmRef] = 0`); one `localShift` block per patch with patch centre, residual shift and the per-(patch, frame) `valid` flag.
- Values are exactly the state the correction kernels consumed: globals as applied by `CGenRealStack` (Fourier phase shift, in place), locals as the post-`MakeRelative` residual field applied by `GCorrectPatchShift`. Coordinates are alignment-image pixels, corner origin, no half-pixel offset; alignment pixel size is the final pixel scaled to the alignment grid (EER super-res aware).

**`-InMotion 1 — replay`**

- New `CLoadAlign` parses `<OutDir>/<movie basename>.mcaln` and validates it against the loaded stack (magic/version, finite values, frame/patch counts, unique indices, geometry match).
- `CAlignMain::mCorrectFromFile` replays buffer prep + forward FFT + in-place global phase shift + `GCorrectPatchShift`, skipping all measurement. Both `MakeRelative` calls are bypassed — file shifts are final. Global-only files go through `CCorrectFullShift`.
- On load failure it warns and falls back to normal measurement.

**Internals**

  - `CFmIntParam` retains immutable pre-throw frame provenance (raw frame count, original source start/count, inclusion flags, aligned-index mapping) that mRemoveFrames() otherwise compacts in place.
  - `CPatchShifts` gains `SetLocalShift` / `SetBadFlag` / `GetBadFlag`.
  - `CLoadAlign.cpp` added to all four makefiles.

## File format (`.mcaln` v1)

Tag-based text; whitespace-separated columns. Blocks appear in the order below.

```
# AreTomo3 MotionAlign 1.0
setting
   raw_frame_count: <int>              # frames in the input movie file
   integrated_frame_count: <int>       # integrated frames before -Throw
   aligned_frame_count: <int>          # integrated frames retained for alignment
   alignment_image_size_px: <Nx> <Ny>
   alignment_pixel_size_A: <float>
   input_to_alignment_scale_xy: <sx> <sy>   # e.g. EER rendering scale
   patches: <nx> <ny>
   fmRef: <int>                        # reference frame, aligned-frame index
   frame_index_base: 0
   pixel_center_offset: 0.0
frameTable
   <integrated_index> <source_start> <source_count> <included> <aligned_index>
globalShift
   <f> <sx> <sy>
localShift
   patchID: <p>
   <f> <cx> <cy> <sx> <sy> <valid>
```

Semantics:

- `frameTable` has one row per integrated frame (pre-throw). Excluded rows carry `included=0`, `aligned_index=-1`. `f` in both shift blocks and `fmRef` are aligned-frame indices.
- Total map: `raw(x, f) = x − S_local(x, f) − glob_f` — corrections are subtracted, the local field is evaluated at the corrected/output coordinate. This is what `mGCorrect3D` computes.
- `globalShift`: FmRef-relative full shifts, `glob[fmRef] = 0`.
- `localShift`: `(cx, cy)` patch centre; `(sx, sy)` the residual shift after global correction — exactly what `CPatchShifts` holds at correction time. `valid` is the per-(patch, frame) flag; the correction kernel skips bad patches, so it must round-trip.
- Units: alignment-image pixels, corner origin, no half-pixel offset. Shifts are in alignment coordinates, not raw-movie pixels; `input_to_alignment_scale_xy` carries any input-to-alignment scaling.
- Readers validate: magic/version; all values finite; counts consistent with the frame table and `patches`; no duplicate `f` / `(p, f)`; `fmRef` and every `f` a valid aligned index; geometry matches the loaded stack.

## Example

Real export from an EER tilt movie (225 raw frames grouped 15→15 integrated frames, 8192² alignment image at 1.54 Å, 5×5 patches, reference frame 7). Abridged — the full file has 15 rows per block and 25 `localShift` blocks (471 lines).

```
# AreTomo3 MotionAlign 1.0
setting
   raw_frame_count: 225
   integrated_frame_count: 15
   aligned_frame_count: 15
   alignment_image_size_px: 8192 8192
   alignment_pixel_size_A: 1.54
   input_to_alignment_scale_xy: 1 1
   patches: 5 5
   fmRef: 7
   frame_index_base: 0
   pixel_center_offset: 0.0
frameTable
      0      0    15 1    0
      1     15    15 1    1
      2     30    15 1    2
      ...
     14    210    15 1   14
globalShift
      0    -1.0000     3.5600
      1    -0.8500     2.7900
      2    -0.6700     2.0700
      ...
      7     0.0000     0.0000
      8    -0.0100    -0.1700
      ...
localShift
   patchID: 0
      0    816.00    864.00    -0.582    -0.679 1
      1    816.00    864.00    -0.561    -0.717 1
      2    816.00    864.00    -0.436    -0.918 1
      ...
localShift
   patchID: 1
      0   2464.00    992.00    -0.370    -0.275 1
      1   2464.00    992.00    -0.369    -0.281 1
      ...
```
