### PR TITLE
feat: -Seed option for reproducible random fill

### DIFF
--- a/CAreTomo3.cpp
+++ b/CAreTomo3.cpp
@@ -57,6 +57,7 @@ int main(int argc, char* argv[])
 	pInput->Parse(argc, argv);
 	pMcInput->Parse(argc, argv);
 	pAtInput->Parse(argc, argv);
+	MU::GGenRandoms::m_iSeed = pInput->m_iSeed; // -Seed
 	//-----------------
 	CAreTomo3Json areTomo3Json;
 	areTomo3Json.Create(acVersion);

--- a/CAreTomo3Json.cpp
+++ b/CAreTomo3Json.cpp
@@ -177,6 +177,9 @@ void CAreTomo3Json::mAddMainInput(void)
 	mAddKeyIntPair(pInput->m_acResumeTag + 1,
 	   &(pInput->m_iResume), 1, 10, !bList, !bEnd);
 	//-----------------
+	mAddKeyIntPair(pInput->m_acSeedTag + 1,
+	   &(pInput->m_iSeed), 1, 10, !bList, !bEnd);
+	//-----------------
 	mAddKeyIntPair(pInput->m_acGpuIDTag + 1,
 	   pInput->m_piGpuIDs, pInput->m_iNumGpus, 10, bList, !bEnd);	
 }

--- a/CInput.cpp
+++ b/CInput.cpp
@@ -44,6 +44,7 @@ CInput::CInput(void)
 	strcpy(m_acCmdTag, "-Cmd");
 	strcpy(m_acResumeTag, "-Resume");
 	strcpy(m_acSerialTag, "-Serial");
+	strcpy(m_acSeedTag, "-Seed");
 	//-----------------
 	m_iNumGpus = 0;
 	m_piGpuIDs = 0L;
@@ -57,6 +58,7 @@ CInput::CInput(void)
 	m_iCmd = 0;
 	m_iResume = 0;
 	m_iSerial = 0;
+	m_iSeed = -1;
 }
 
 CInput::~CInput(void)
@@ -138,6 +140,16 @@ void CInput::ShowTags(void)
 	   "  2. -Resume 1 starts from what are left by skipping all the mdoc\n"
 	   "     files in MdocDone.txt file in the output folder.\n\n",
 	   m_acResumeTag); 
+	//-----------------
+	printf("%-15s\n"
+	   "  1. Seed of the random number generator that fills the empty\n"
+	   "     regions of shifted/rotated images (and SART volumes).\n"
+	   "  2. Default -1 seeds it with the wall-clock time, so results\n"
+	   "     vary slightly from run to run. Any value from 0 to\n"
+	   "     2147483647 fixes the seed: runs with the same input and\n"
+	   "     parameters then give bit-identical alignment and volumes\n"
+	   "     (this also requires the same GPU model, driver and CUDA).\n\n",
+	   m_acSeedTag);
 	//-----------------
 	printf("%-15s\n", m_acGpuIDTag);
 	printf("   GPU IDs. Default 0.\n");
@@ -227,6 +239,10 @@ void CInput::Parse(int argc, char* argv[])
 	if(aiRange[1] > 1) aiRange[1] = 1;
 	aParseArgs.GetVals(aiRange, &m_iResume);
 	//-----------------
+	aParseArgs.FindVals(m_acSeedTag, aiRange);
+	if(aiRange[1] > 1) aiRange[1] = 1;
+	aParseArgs.GetVals(aiRange, &m_iSeed);
+	//-----------------
 	mExtractInDir();
 	mAddEndSlash(m_acOutDir);
 	mAddEndSlash(m_acLogDir);
@@ -253,6 +269,7 @@ void CInput::mPrint(void)
 	printf("%-15s  %d\n", m_acSerialTag, m_iSerial);
 	printf("%-15s  %d\n", m_acCmdTag, m_iCmd);
 	printf("%-15s  %d\n", m_acResumeTag, m_iResume);
+	printf("%-15s  %d\n", m_acSeedTag, m_iSeed);
 	//-----------------
 	printf("%-15s  %d\n", m_acSplitSumTag, m_iSplitSum);
 	//-----------------

--- a/CMcAreTomoInc.h
+++ b/CMcAreTomoInc.h
@@ -40,6 +40,7 @@ public:
 	int m_iCmd;
 	int m_iResume;
 	int m_iSerial;
+	int m_iSeed;
 	//-----------------
 	char m_acInPrefixTag[32];
 	char m_acInSuffixTag[32];
@@ -59,6 +60,7 @@ public:
 	char m_acCmdTag[32];
 	char m_acResumeTag[32];
 	char m_acSerialTag[32];
+	char m_acSeedTag[32];
 private:
         CInput(void);
 	void mExtractInDir(void);

--- a/MaUtil/CMaUtilInc.h
+++ b/MaUtil/CMaUtilInc.h
@@ -229,6 +229,10 @@ public:
 	~GGenRandoms(void);
 	void DoIt(int iSize);
 	//---------------------------
+	// -Seed: < 0 (default) seeds cuRAND with time(0L) as before;
+	// >= 0 uses this fixed seed so that runs are reproducible.
+	static int m_iSeed;
+	//---------------------------
 	int* m_giRandoms;
 	int m_iSize;
 };

--- a/MaUtil/GGenRandoms.cu
+++ b/MaUtil/GGenRandoms.cu
@@ -4,6 +4,8 @@
 
 using namespace McAreTomo::MaUtil;
 
+int GGenRandoms::m_iSeed = -1;
+
 static __global__ void mGGenRandNumbers
 (	int* giOutput,
 	int iSize,
@@ -39,7 +41,8 @@ void GGenRandoms::DoIt(int iSize)
 	}
 	m_iSize = iSize;
 	//---------------------------
-	unsigned long long seed = time(0L);
+	unsigned long long seed = (m_iSeed >= 0) ?
+	   (unsigned long long)m_iSeed : (unsigned long long)time(0L);
 	dim3 aBlockDim(1024, 1);
 	dim3 aGridDim(1, 1);
 	aGridDim.x = (m_iSize + aBlockDim.x - 1) / aBlockDim.x;

--- a/Readme.txt
+++ b/Readme.txt
@@ -705,3 +705,14 @@ Changes:
    1) Parse the DateTime field in MDOC file instead of ZValue to determine
       the correct acquisition order. Note that the format of DateTime are
       similar to "01-Aug-2024 15:27-36", "02-Qug-2024 07:52:28".
+
+AreTomo3 2.3.2 [09-01-2026]
+---------------------------
+Changes:
+   1) Added -Seed. Since 2.2.4 the empty regions of shifted/rotated images
+      (MaUtil/GFillEmpty2D.cu, used by tilt series alignment and by WBP/SART
+      reconstruction) are filled with randomly chosen pixels of the same image
+      whose cuRAND seed was time(0L), so identical inputs gave slightly
+      different alignments and volumes from run to run. -Seed N (N >= 0)
+      fixes that seed and makes runs with the same inputs and parameters
+      bit-identical. The default (-Seed -1) keeps the previous behavior.


### PR DESCRIPTION
## Problem

Since AreTomo3 2.2.4 (commit 4066d03) the empty regions of every shifted/rotated projection, and of SART
volumes, are filled by `MaUtil/GFillEmpty2D.cu` with values copied from randomly chosen pixels of the same
image. The random index table is generated by cuRAND in `MaUtil/GGenRandoms.cu` with

```cpp
unsigned long long seed = time(0L);   // MaUtil/GGenRandoms.cu:42
```

i.e. the wall-clock second at which each `GFillEmpty2D::SetSize` call happens (20–30 times per tilt series).
Two runs on byte-identical inputs therefore give different results in every `-Cmd` mode, because the filled
pixels (about 4 % of each projection from the tilt-axis rotation alone, up to 18 % on strongly shifted tilts)
are spread over the whole volume by the ramp filter and the back projection, and the same projections feed
the coarse and projection-matching alignment. 

Pinning libc `time()` (an `LD_PRELOAD` shim returning a constant) makes both workflows bit-identical, so this
seed is the only source of non-reproducibility; before 2.2.4 the fill used a pixel-index-seeded generator and
was reproducible. 

## Change

New global option `-Seed <int>` (in `CInput`):

* `-Seed N` with `N >= 0` uses `N` as the cuRAND seed. Runs with the same inputs, parameters, GPU model and
  CUDA/cuFFT version are then bit-identical: alignment (`.aln`), CTF file and volumes, WBP and SART, all `-Cmd`
  modes.
* Default `-Seed -1` keeps the previous `time(0L)` behaviour, so nothing changes for existing users.
* The value is echoed with the other parameters and stored as `"Seed"` in `AreTomo3_Session.json`; `--help`
  documents it.
* Implementation: `main()` copies `CInput::m_iSeed` into a write-once static `GGenRandoms::m_iSeed` right after
  parsing, before any GPU thread exists, so `MaUtil` stays independent of `CInput`; `GGenRandoms::DoIt` uses
  the static instead of `time(0L)` when it is `>= 0`. 7 files, +42/−1 lines, no makefile changes.
* `Readme.txt` gets a changelog entry under a `2.3.2` heading; the version string in `CAreTomo3.cpp` is left
  for the maintainer to bump.

Usage: `AreTomo3 -Cmd 2 ... -Seed 42`

## Verification

To reproduce the underlying issue with an unmodified build: run the same `-Cmd 2` command twice on one tilt
series and compare the volumes (any two runs started in different seconds differ); a fixed seed, or pinning
`time()` with a preload shim, makes them identical.

## Note (not changed here)

`CInput.cpp` lines 198–203 contain a stray second read of `-Serial` that reuses the `aiRange` of `-SplitSum`:
if `-SplitSum N` is given without `-Serial`, `m_iSerial` ends up as `N`. Left untouched to keep this PR focused.
